### PR TITLE
Add storeAppName and storeCountry configuration options for iOS URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ const _config = {
     ]
   },
   shouldBoldLastButton: true,
-  storeAppName: 'appName'
+  storeAppName: 'appName',
+  storeCountry: 'us'
 };
 
 async function _isAwaitingRating() {
@@ -84,7 +85,7 @@ export default class RatingRequestor {
 		_config.appStoreId = appStoreId;
 
 		this.storeUrl = Platform.select({
-      ios: `https://itunes.apple.com/us/app/${_config.storeAppName}/id${_config.appStoreId}`,
+      ios: `https://itunes.apple.com/${_config.storeCountry}/app/${_config.storeAppName}/id${_config.appStoreId}`,
       android: `market://details?id=${_config.appStoreId}`,
     });
   }

--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ const _config = {
       buttonTypes.POSITIVE_ACCEPT
     ]
   },
-  shouldBoldLastButton: true
+  shouldBoldLastButton: true,
+  storeAppName: 'appName'
 };
 
 async function _isAwaitingRating() {
@@ -83,7 +84,7 @@ export default class RatingRequestor {
 		_config.appStoreId = appStoreId;
 
 		this.storeUrl = Platform.select({
-      ios: `https://itunes.apple.com/us/app/appName/id${_config.appStoreId}`,
+      ios: `https://itunes.apple.com/us/app/${_config.storeAppName}/id${_config.appStoreId}`,
       android: `market://details?id=${_config.appStoreId}`,
     });
   }


### PR DESCRIPTION
`https://itunes.apple.com/us/app/appName/id1234567890` becomes `https://itunes.apple.com/nl/app/configured-app-name/id1234567890`

Usage:
```
new RatingRequestor(appId, {
    storeAppName: 'my-app-name', // default is 'appName'
    storeCountry: 'nl' // default is 'us'
});
```

All appNames work, but this looks less like a 'standard' implementation

For example, subwaySurfers would look strange: https://itunes.apple.com/nl/app/appName/id512939461 In stead with this implementation it could look like: https://itunes.apple.com/nl/app/subway-surfers/id512939461

Both URLs work, but in my opinion the second one looks better/more professional.

This feature is backwards compatible, so updating with this fix would not break anything


Edit:
I also added the store country to this PR

