### PR TITLE
Allow callback to handle rate-linking

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,8 +119,10 @@ export default class RatingRequestor {
         text: _config.actionLabels.accept,
         onPress: () => {
           RatingsData.recordRated();
-          callback(true, "accept");
-          Linking.openURL(this.storeUrl);
+          let res = callback(true, "accept");
+          if (res !== false) {
+            Linking.openURL(this.storeUrl);
+          }
         },
         style: "default",
       }


### PR DESCRIPTION
This PR allows the app to handle the "Linking" part, which can be useful if the app wants to use the ios native rating dialog for example.

```
import * as StoreReview from 'react-native-store-review';

if (user_saved_the_world) {
	RatingTracker.handlePositiveEvent(function(didAppear, userDecision) {
		if (didAppear) {
			switch(userDecision)
			{
				case 'decline': console.log('User declined to rate'); break;
				case 'delay'  : console.log('User delayed rating, will be asked later'); break;
				case 'accept' :
                                        console.log('User accepted invitation to rate, redirected to app store');
                                        if (StoreReview.isAvailable) {
                                               // Native store review available 
                                               StoreReview.requestReview();
                                               return false; // Disable default linking to appstore
                                        }
                                        break;
			}
		} else {
			console.log('Request popup did not pop up. May appear on future positive events.');
		} 
	});
}
```