### PR TITLE
Use AsyncStorage from react native community

### DIFF
--- a/RatingsData.js
+++ b/RatingsData.js
@@ -1,4 +1,5 @@
-import React, { AsyncStorage } from 'react-native';
+import React from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
 const keyPrefix = '@RatingRequestData.';
 const eventCountKey = keyPrefix + 'positiveEventCount';

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/jlyman/react-native-rating-requestor#readme",
   "peerDependencies": {
-    "react-native": ">= 0.26.0"
+    "react-native": ">= 0.26.0",
+    "@react-native-community/async-storage": "^1.4.2"
   }
 }


### PR DESCRIPTION
As the per React Native official [docs](https://facebook.github.io/react-native/docs/asyncstorage), AsyncStorage from the core react-native project is no longer supported.

This PR is simply to update the library to the using the supported version from react-native-community.