### PR TITLE
chore(deps): Updated async storage dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Rating Requestor is a very simple JS module that you simply instantiate and 
 
 You'll probably also want to install the peer dependencies as well: 
 
-    npm i --save @react-native-community/async-storage react-native-store-review
+    npm i --save @react-native-async-storage/async-storage react-native-store-review
 
  You may also need to `link` in or `pod install` the native modules from the peer dependencies, which varies depending on the version of React Native you are using.
 

--- a/RatingsData.js
+++ b/RatingsData.js
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const keyPrefix = '@RatingRequestData.';
 const eventCountKey = keyPrefix + 'positiveEventCount';

--- a/examples/RatingRequestorExample/ios/Podfile.lock
+++ b/examples/RatingRequestorExample/ios/Podfile.lock
@@ -109,7 +109,7 @@ DEPENDENCIES:
   - React-RCTText (from `../node_modules/react-native/Libraries/Text`)
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-RCTWebSocket (from `../node_modules/react-native/Libraries/WebSocket`)
-  - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNStoreReview (from `../node_modules/react-native-store-review/ios`)
   - yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -161,7 +161,7 @@ EXTERNAL SOURCES:
   React-RCTWebSocket:
     :path: "../node_modules/react-native/Libraries/WebSocket"
   RNCAsyncStorage:
-    :path: "../node_modules/@react-native-community/async-storage"
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNStoreReview:
     :path: "../node_modules/react-native-store-review/ios"
   yoga:

--- a/examples/RatingRequestorExample/package.json
+++ b/examples/RatingRequestorExample/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@react-native-community/async-storage": "^1.6.1",
+    "@react-native-async-storage/async-storage": "^1.13.2",
     "react": "16.8.6",
     "react-native": "0.60.4",
     "react-native-rating-requestor": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/jlyman/react-native-rating-requestor#readme",
   "peerDependencies": {
-    "@react-native-community/async-storage": "^1.4.2",
+    "@react-native-async-storage/async-storage": "^1.13.2",
     "react-native": ">= 0.57.0",
     "react-native-store-review": "^0.1.5"
   }


### PR DESCRIPTION
The async storage package has changed names, see here:

https://react-native-async-storage.github.io/async-storage/